### PR TITLE
update to allow for alpha in texture images

### DIFF
--- a/src/shaders/precompiled/image.js
+++ b/src/shaders/precompiled/image.js
@@ -15,6 +15,6 @@ export default {
         varying mediump vec2 texcoord;
         uniform sampler2D texture;
         void main(void) {
-            gl_FragColor = vec4(texture2D(texture, texcoord).rgb,1.0);
+            gl_FragColor = vec4(texture2D(texture, texcoord).rgba);
         }`
 }


### PR DESCRIPTION
allows the image to dictate the alpha values rather than a solid white background.